### PR TITLE
Create testing structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 droid.yml
 shell.nix
 .coverage
+droid.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .DS_Store
 droid.yml
 shell.nix
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.7"
+install:
+  - pip install -r requirements.txt
+script:
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "3.7"
 install:
   - pip install -r requirements.txt
+  - pip install -e .
 script:
   - pytest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # DROID is a ROBOT Ontology Development Interface
 
+[![Build Status](https://travis-ci.org/ontodev/droid.svg?branch=master)](https://travis-ci.org/ontodev/droid)
+
 DROID is a web-based interface for ontology development. Given an ontology project that uses ROBOT or ODK and GitHub, DROID presents authorized users with a subset of that lower-level functionality, including common ontology browsing, editing, quality control, and version control tasks.
-                                                                                                                                                                      
+
 The goal is just to present existing functionality, not to replace it. So DROID reads the files in the GitHub repository, runs tasks from the Makefile, helps users edit existing templates, and pushes changes back to GitHub.
 
 DROID is in early development and is designed to work on Unix (Linux, macOS) systems. It is build on [Flask](https://palletsprojects.com/p/flask/). You need Python 3 and Java installed, and we recommend using `venv`. Clone this repository into a fresh directory, set up `venv`, install requirements with `pip`, and then run `./droid`:

--- a/droid/__init__.py
+++ b/droid/__init__.py
@@ -1,4 +1,6 @@
-import os, yaml
+import os
+import yaml
+
 
 def create_app(test_config=None):
     # Create droid.yml with wizard if not found

--- a/droid/wizard.py
+++ b/droid/wizard.py
@@ -3,10 +3,10 @@ import os
 import sys
 
 
-def main():
-    '''Get user input to create a config file. Validate fields and write
+def run():
+    """Get user input to create a config file. Validate fields and write
     to droid.yml file.
-    '''
+    """
     if os.path.exists('droid.yml'):
         print('A configuration file already exists!')
         try_continue()
@@ -38,8 +38,8 @@ project:
 
 
 def try_continue():
-    '''Get user input if process should continue. Repeat until user enters y/n.
-    '''
+    """Get user input if process should continue. Repeat until user enters y/n.
+    """
     while True:
         resp = input('Do you wish to overwrite? [y/n] ')
         if resp.lower() == 'n':
@@ -51,4 +51,4 @@ def try_continue():
 
 
 if __name__ == '__main__':
-    main()
+    run()

--- a/droid/wizard.py
+++ b/droid/wizard.py
@@ -15,13 +15,34 @@ def run():
     gh_user = input('GitHub organization or username: ')
     gh_project = input('GitHub project name: ')
 
-    # Check that the GitHub repo actually exists
+    valid = validate_repo(gh_user, gh_project)
+    if not valid:
+        print('WARN: GitHub repo {0}/{1} does not exist!'.format(gh_user, gh_project))
+    create_config(p_name, gh_user, gh_project)
+
+
+def validate_repo(gh_user, gh_project):
+    """Check that the GitHub repository for user exists.
+
+    Args:
+        gh_user (str): GitHub user or organization name
+        gh_project (str): GitHub project name
+    """
     gh_repo = 'https://github.com/{0}/{1}'.format(gh_user, gh_project)
     req = requests.get(gh_repo)
     if req.status_code != 200:
-        print('WARN: GitHub repo {0}/{1} does not exist!'.format(
-            gh_user, gh_project))
+        return False
+    return True
 
+
+def create_config(p_name, gh_user, gh_project):
+    """Create a configuration YAML file.
+
+    Args:
+        p_name (str): project name
+        gh_user (str): GitHub user or organization name
+        gh_project (str): GitHub project name
+    """
     yml = '''droid:
   configuration version: 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pyyaml
 flask
 requests
+pytest
+coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[tool:pytest]
+testpaths = tests
+
+[coverage:run]
+branch = True
+source =
+    droid

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name='droid',
+    version='1.0',
+    packages=['droid'],
+    url='https://www.github.com/ontodev/droid',
+    license='',
+    author='James Overton, Rebecca Jackson',
+    author_email='james@overton.ca, rbca.jackson@gmail.com',
+    description='DROID is a ROBOT Ontology Development Interface'
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,6 @@ import tempfile
 import pytest
 from droid import create_app
 
-with open(os.path.join(os.path.dirname(__file__), 'data.sql'), 'rb') as f:
-    _data_sql = f.read().decode('utf8')
-
 
 @pytest.fixture
 def app():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,52 @@
+import os
+import tempfile
+
+import pytest
+from droid import create_app
+
+with open(os.path.join(os.path.dirname(__file__), 'data.sql'), 'rb') as f:
+    _data_sql = f.read().decode('utf8')
+
+
+@pytest.fixture
+def app():
+    db_fd, db_path = tempfile.mkstemp()
+
+    app = create_app({
+        'TESTING': True,
+        'DATABASE': db_path,
+    })
+
+    yield app
+
+    os.close(db_fd)
+    os.unlink(db_path)
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def runner(app):
+    return app.test_cli_runner()
+
+
+class AuthActions(object):
+    def __init__(self, client):
+        self._client = client
+
+    def login(self, username='test', password='test'):
+        return self._client.post(
+            '/auth/login',
+            data={'username': username, 'password': password}
+        )
+
+    def logout(self):
+        return self._client.get('/auth/logout')
+
+
+@pytest.fixture
+def auth(client):
+    return AuthActions(client)

--- a/tests/data.sql
+++ b/tests/data.sql
@@ -1,0 +1,8 @@
+INSERT INTO user (username, password)
+VALUES
+  ('test', 'pbkdf2:sha256:50000$TCI4GzcX$0de171a4f4dac32e3364c7ddc7c14f3e2fa61f2d17574483f7ffbb431b4acb2f'),
+  ('other', 'pbkdf2:sha256:50000$kJPKsz6N$d2d4784f1b030a9761f5ccaeeaca413f27f2ecb76d6168407af962ddce849f79');
+
+INSERT INTO post (title, body, author_id, created)
+VALUES
+  ('test title', 'test' || x'0a' || 'body', 1, '2018-01-01 00:00:00');

--- a/tests/data.sql
+++ b/tests/data.sql
@@ -1,8 +1,0 @@
-INSERT INTO user (username, password)
-VALUES
-  ('test', 'pbkdf2:sha256:50000$TCI4GzcX$0de171a4f4dac32e3364c7ddc7c14f3e2fa61f2d17574483f7ffbb431b4acb2f'),
-  ('other', 'pbkdf2:sha256:50000$kJPKsz6N$d2d4784f1b030a9761f5ccaeeaca413f27f2ecb76d6168407af962ddce849f79');
-
-INSERT INTO post (title, body, author_id, created)
-VALUES
-  ('test title', 'test' || x'0a' || 'body', 1, '2018-01-01 00:00:00');

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,11 @@
+from droid import create_app
+
+
+def test_config():
+    assert not create_app().testing
+    assert create_app({'TESTING': True}).testing
+
+
+def test_hello(client):
+    response = client.get('/hello')
+    assert response.data == b'Hello, World!'

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,11 +1,22 @@
 from droid import create_app
+from droid import wizard
+
+import os
+
+
+def setup_factory():
+    if not os.path.exists('droid.yml'):
+        # Create a phony droid.yml file
+        wizard.create_config('droid_test', 'ontodev', 'droid')
 
 
 def test_config():
+    setup_factory()
     assert not create_app().testing
     assert create_app({'TESTING': True}).testing
 
 
 def test_hello(client):
+    setup_factory()
     response = client.get('/hello')
     assert response.data == b'Hello, World!'

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,0 +1,15 @@
+from droid import wizard
+
+
+def test_valid_repo():
+    gh_user = 'ontodev'
+    gh_project = 'DROID'
+    valid = wizard.validate_repo(gh_user, gh_project)
+    assert valid
+
+
+def test_invalid_repo():
+    gh_user = 'not_a_user'
+    gh_project = 'not_a_repository'
+    valid = wizard.validate_repo(gh_user, gh_project)
+    assert not valid

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -3,7 +3,7 @@ from droid import wizard
 
 def test_valid_repo():
     gh_user = 'ontodev'
-    gh_project = 'DROID'
+    gh_project = 'droid'
     valid = wizard.validate_repo(gh_user, gh_project)
     assert valid
 


### PR DESCRIPTION
See #4 

There's not much to test right now, so I just added the framework based on https://flask.palletsprojects.com/en/1.1.x/tutorial/tests/

I also added a small test for the `wizard.py` script.

Tests pass with `python3 -m pytest`:
```
============================= test session starts ==============================
platform darwin -- Python 3.7.5, pytest-5.3.4, py-1.8.1, pluggy-0.13.1
rootdir: /Users/tauber/github/DROID, inifile: setup.cfg, testpaths: tests
collected 4 items                                                              

tests/test_factory.py ..                                                 [ 50%]
tests/test_wizard.py ..                                                  [100%]

============================== 4 passed in 1.61s ===============================
```

Current coverage:
```
Name                Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------
droid/__init__.py      14      3      6      3    70%
droid/server.py        15      0      2      0   100%
droid/wizard.py        35     22     12      1    34%
-----------------------------------------------------
TOTAL                  64     25     20      4    56%
```