### PR TITLE
fix bug when checking out/creating a branch, redirect to previous page after login, only use 'exec' sometimes

### DIFF
--- a/src/droid/branches.clj
+++ b/src/droid/branches.clj
@@ -318,10 +318,10 @@
                           (str "https://github.com/" org "/" repo) branch-name
                           :dir (get-workspace-dir project-name)]
                          ["bash" "-c"
-                          (str "exec grep '.git-credentials' .gitignore || "
+                          (str "grep -qs '.git-credentials' .gitignore || "
                                "echo '.git-credentials' >> .gitignore")
                           :dir cloned-branch-dir]
-                         ["bash" "-c" (str "exec git config credential.helper "
+                         ["bash" "-c" (str "git config credential.helper "
                                            "'store --file=.git-credentials'")
                           :dir cloned-branch-dir]
                          ["git" "config" "--local" "color.ui" "always" :dir cloned-branch-dir]])
@@ -352,11 +352,11 @@
                           (str "https://github.com/" org "/" repo) branch-name
                           :dir (get-workspace-dir project-name)]
                          ["bash" "-c"
-                          (str "exec grep '.git-credentials' .gitignore || "
+                          (str "grep -qs '.git-credentials' .gitignore || "
                                "echo '.git-credentials' >> .gitignore")
                           :dir new-branch-dir]])
       (store-creds all-branches project-name branch-name request)
-      (cmd/run-commands [["bash" "-c" (str "exec git config credential.helper "
+      (cmd/run-commands [["bash" "-c" (str "git config credential.helper "
                                            "'store --file=.git-credentials'")
                           :dir new-branch-dir]
                          ["git" "config" "--local" "color.ui" "always" :dir new-branch-dir]

--- a/src/droid/handler.clj
+++ b/src/droid/handler.clj
@@ -103,9 +103,7 @@
          :scopes           ["user:email public_repo"]
          :launch-uri       "/oauth2/github"
          :redirect-uri     "/oauth2/github/callback"
-         :landing-uri      "/just_logged_in"
-         ;;:redirect-handler "/"
-         }})
+         :landing-uri      "/just_logged_in"}})
       (wrap-session
        {:store db/session-store})
       (wrap-defaults

--- a/src/droid/handler.clj
+++ b/src/droid/handler.clj
@@ -78,6 +78,7 @@
 
 (defroutes app-routes
   (GET "/" [] html/render-index)
+  (GET "/just_logged_in" [] html/just-logged-in)
   (POST "/github_webhook" [] html/render-github-webook-response)
   (GET "/:project-name" [] html/render-project)
   (GET "/:project-name/branches/:branch-name/views/:view-path{.+}" [] html/view-file)
@@ -102,7 +103,9 @@
          :scopes           ["user:email public_repo"]
          :launch-uri       "/oauth2/github"
          :redirect-uri     "/oauth2/github/callback"
-         :landing-uri      "/"}})
+         :landing-uri      "/just_logged_in"
+         ;;:redirect-handler "/"
+         }})
       (wrap-session
        {:store db/session-store})
       (wrap-defaults

--- a/src/droid/html.clj
+++ b/src/droid/html.clj
@@ -491,7 +491,6 @@
     {:keys [just-logged-out rebuild-containers rebuild-launched reset really-reset]} :params,
     {{:keys [login]} :user} :session,
     :as request}]
-  ;;(clojure.pprint/pprint request)
   (log/debug "Processing request in index with params:" params)
   (letfn [(site-admin? []
             (some #(= login %) (get-config :site-admin-github-ids)))]

--- a/src/droid/html.clj
+++ b/src/droid/html.clj
@@ -390,11 +390,11 @@
                         (do (spit tmp-infile query-string)
                             (cmd/run-command
                              ["bash" "-c"
-                              (str "exec ./" basename " < " tmp-infile " > " tmp-outfile)
+                              (str "./" basename " < " tmp-infile " > " tmp-outfile)
                               :dir dirname :env cgi-input-env]
                              timeout branch-contents))
                         (cmd/run-command
-                         ["bash" "-c" (str "exec ./" basename " > " tmp-outfile)
+                         ["bash" "-c" (str "./" basename " > " tmp-outfile)
                           :dir dirname :env cgi-input-env]
                          timeout branch-contents))
           ;; We expect a blank line separating the response's header and body:
@@ -474,12 +474,24 @@
                   (send #(assoc % :command basename :action basename)))
               (redirect branch-url))))))))
 
+(defn just-logged-in
+  "After logging into DROID a user is directed here, which in turn redirects the user either to the
+  page she was previously on, or if that is unknown, to the index page."
+  [{:keys [headers] :as request}]
+  (let [{host "host", referer "referer"} headers
+        pattern (re-pattern (str "https?://" host "/(.+)"))
+        rel-url (-> (and referer host (re-matches pattern referer))
+                    (second)
+                    (#(when % (string/replace % #"\?.+$" ""))))]
+    (redirect (or rel-url "/"))))
+
 (defn render-index
   "Render the index page"
   [{:keys [params]
     {:keys [just-logged-out rebuild-containers rebuild-launched reset really-reset]} :params,
     {{:keys [login]} :user} :session,
     :as request}]
+  ;;(clojure.pprint/pprint request)
   (log/debug "Processing request in index with params:" params)
   (letfn [(site-admin? []
             (some #(= login %) (get-config :site-admin-github-ids)))]
@@ -919,7 +931,7 @@
                        a2h-exit-code] (do (log/debug "Colourizing console using ansi2html ...")
                                           (cmd/run-command
                                            ["bash" "-c"
-                                            (str "exec ansi2html -i < console.txt > console.html")
+                                            (str "ansi2html -i < console.txt > console.html")
                                             :dir pwd]))
                       colourized-console (if (not= @a2h-exit-code 0)
                                            (do (log/error "Unable to colourize console.")
@@ -1279,6 +1291,9 @@
                                 project-name "for user" (-> request :session :user :login))
                       (let [[process exit-code]
                             (cmd/run-command ["bash" "-c"
+                                              ;; `exec` is needed here to prevent the make process from
+                                              ;; detaching from the parent (since that would make it
+                                              ;; difficult to destroy later).
                                               (str "exec make " view-path
                                                    " > " (get-temp-dir project-name branch-name)
                                                    "/console.txt 2>&1")


### PR DESCRIPTION
fix bug that causes droid to choke when checking out a branch if there is no .gitignore file; redirect the user to the page she was on after login; don't prefix commands with 'exec' unless we need to keep track of them

closes #57
closes #54