### PR TITLE
increase maximum number of remote branches to fetch to 100 and display a warning if a repo contains more than this number

### DIFF
--- a/src/droid/github.clj
+++ b/src/droid/github.clj
@@ -173,6 +173,10 @@
                                       nil)))))))
        (apply merge)))
 
+;; The maximum number of branches DROID is allowed to display. This cannot be greater than 100
+;; (see https://docs.github.com/en/rest/reference/repos#list-branches)
+(def max-remotes 100)
+
 (defn get-remote-branches
   "Call the GitHub API to get the list of remote branches for the given project, using the given
   login and token for authentication."
@@ -196,7 +200,8 @@
                                      "for list of remote branches of project" project-name
                                      (when login
                                        (str "using " login "'s credentials")))
-                          (branches org repo {:oauth-token token}))]
+                          (branches org repo {:oauth-token token
+                                              :per-page max-remotes}))]
     (if (= (type remote-branches) clojure.lang.PersistentHashMap)
       (do (log/error
            "Request to retrieve remote branches of project" project-name

--- a/src/droid/html.clj
+++ b/src/droid/html.clj
@@ -1198,6 +1198,11 @@
                             :data-toggle "tooltip"
                             :title "Rebuild all containers for this project"}
                         "Rebuild all containers"])]
+                    (when (-> @branches/remote-branches (get (keyword project-name)) (count)
+                              (>= gh/max-remotes))
+                      [:div {:class "alert alert-warning"}
+                       "Warning: Your GitHub repository includes " gh/max-remotes " or more "
+                       "branches, which is more than DROID can display."])
                     (render-project-branches project-name
                                              (read-only? request)
                                              (site-admin? request))]})))))


### PR DESCRIPTION
Closes #113 

*Note:* I have created more than 100 branches on this repo: https://github.com/lmcmicu/for-testing-with-droid, which you may use to verify this.