### PR TITLE
Bug fixes and improvements

### DIFF
--- a/src/droid/html.clj
+++ b/src/droid/html.clj
@@ -511,7 +511,7 @@
                              "CONTENT_LENGTH" ""
                              "CONTENT_TYPE" ""
                              "GATEWAY_INTERFACE" "CGI/1.1"
-                             "PATH_INFO" path-info
+                             "PATH_INFO" (or (not-empty path-info) "/")
                              "PATH_TRANSLATED" ""
                              "QUERY_STRING" ""
                              "REMOTE_ADDR" remote-addr


### PR DESCRIPTION
- Verify that the branch exists when accessing a view; closes #120.
- Set the `PATH_INFO` to `/` by default when running CGI scripts; closes #123 
- set the CGI `SCRIPT_NAME` to the URL path; closes #124